### PR TITLE
Resolves #2: fix failing negative test case for fibonacci

### DIFF
--- a/fib.py
+++ b/fib.py
@@ -6,6 +6,7 @@ The zeroth number in the fibonacci sequence is 0. The first number is 1
 Negative numbers should return None
 """
 def fibonacci(position):
+  if (position < 0): return None;
   if(position == 1 or position == 2):
     return 1
   return fibonacci(position - 1) + fibonacci(position - 2)


### PR DESCRIPTION
This test was failing because any negative input to the fibonacci function would recursively call the function until termination due to stack overflow or some other issue. The fix was to make an explicit case for negative numbers that would return `None`, as described in the function specs. This was tested by trying out several negative numbers as inputs locally, all of which succeeded in printing out `None`.