### PR TITLE
Resolve #1: fix test_zeroth_fibonacci failing

### DIFF
--- a/fib.py
+++ b/fib.py
@@ -6,9 +6,11 @@ The zeroth number in the fibonacci sequence is 0. The first number is 1
 Negative numbers should return None
 """
 def fibonacci(position):
-  if(position == 1 or position == 2):
-    return 1
-  return fibonacci(position - 1) + fibonacci(position - 2)
+    if(position == 0):
+      return 0
+    if(position == 1 or position == 2):
+      return 1
+    return fibonacci(position - 1) + fibonacci(position - 2)
 
 
 


### PR DESCRIPTION
The test_zeroth_fibonacci was failing because when position is equal to 0 the function would be call it self recursively without reaching the base case. 
This is fixed by adding a base case for the zeroth fib number as a base case.